### PR TITLE
Upgrade to RSpec3

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -38,11 +38,11 @@ end
 group :development, :test do
   gem 'dotenv-rails'
   gem 'factory_girl_rails'
-  gem 'rspec-rails', '~> 2.14.0'
+  gem 'rspec-rails', '~> 3.0.0'
 end
 
 group :test do
-  gem 'capybara-webkit', '>= 1.0.0'
+  gem 'capybara-webkit', '>= 1.2.0'
   gem 'database_cleaner'
   gem 'shoulda-matchers', require: false
   gem 'simplecov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,18 +201,22 @@ GEM
     recipient_interceptor (0.1.2)
       mail
     remotipart (1.2.1)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.6)
-    rspec-rails (2.14.2)
+    rspec-core (3.0.3)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.3)
+      rspec-support (~> 3.0.0)
+    rspec-rails (3.0.2)
       actionpack (>= 3.0)
-      activemodel (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.3)
     safe_yaml (1.0.3)
     sass (3.2.19)
     sass-rails (4.0.3)
@@ -275,7 +279,7 @@ PLATFORMS
 DEPENDENCIES
   aasm
   active_model_serializers
-  capybara-webkit (>= 1.0.0)
+  capybara-webkit (>= 1.2.0)
   coffee-rails
   database_cleaner
   delayed_job_active_record
@@ -299,7 +303,7 @@ DEPENDENCIES
   rails_12factor
   rails_admin
   recipient_interceptor
-  rspec-rails (~> 2.14.0)
+  rspec-rails (~> 3.0.0)
   sass-rails (~> 4.0.3)
   shoulda-matchers
   simple_form

--- a/spec/lib/fake_geocoder_spec.rb
+++ b/spec/lib/fake_geocoder_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe FakeGeocoder do
   it 'allows for setting and retrieving geocoded values' do

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe Place do
   it { should validate_presence_of(:name) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,26 @@
+require 'simplecov'
+SimpleCov.start 'rails'
+
+ENV['RAILS_ENV'] = 'test'
+
+require File.expand_path('../../config/environment', __FILE__)
+
+require 'rspec/rails'
+require 'shoulda/matchers'
+
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |file| require file }
+
+module Features
+  # Extend this module in spec/support/features/*.rb
+end
+
+RSpec.configure do |config|
+  config.include Features, type: :feature
+  config.infer_base_class_for_anonymous_controllers = false
+  config.infer_spec_type_from_file_location!
+  config.use_transactional_fixtures = false
+  config.include GeocoderHelper
+end
+
+ActiveRecord::Migration.maintain_test_schema!
+Capybara.javascript_driver = :webkit

--- a/spec/requests/api/v1/user_can_list_kinds_spec.rb
+++ b/spec/requests/api/v1/user_can_list_kinds_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'GET /api/v1/kinds' do
   it 'returns kinds list' do

--- a/spec/requests/api/v1/user_can_list_places_spec.rb
+++ b/spec/requests/api/v1/user_can_list_places_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'GET /api/v1/places' do
   it 'returns places list' do

--- a/spec/requests/api/v1/user_can_suggest_a_place_spec.rb
+++ b/spec/requests/api/v1/user_can_suggest_a_place_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe 'POST /api/v1/places' do
   it 'creates a new place and returns it' do

--- a/spec/services/csv_import_service_spec.rb
+++ b/spec/services/csv_import_service_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe CsvImportService do
   describe '#valid?' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,33 +1,16 @@
-require 'simplecov'
-SimpleCov.start 'rails'
-
-ENV['RAILS_ENV'] = 'test'
-
-require File.expand_path('../../config/environment', __FILE__)
-
-require 'rspec/rails'
-require 'shoulda/matchers'
 require 'webmock/rspec'
 
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |file| require file }
-
-module Features
-  # Extend this module in spec/support/features/*.rb
-end
-
+# http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
   end
 
-  config.fail_fast = true
-  config.include Features, type: :feature
-  config.infer_base_class_for_anonymous_controllers = false
-  config.order = 'random'
-  config.use_transactional_fixtures = false
-  config.include GeocoderHelper
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :expect
+  end
+
+  config.order = :random
 end
 
-ActiveRecord::Migration.maintain_test_schema!
-Capybara.javascript_driver = :webkit
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
RSpec 3.x introduces a `spec/rails_helper.rb` file
which contains all dependencies necessary to run specs that need Rails.
- Move Rails-specific things to rails_helper.rb.
- Require spec_helper.rb from rails_helper.rb.
- We do not need to require `spec_helper` manually.
  It is required for us in `.rspec`:
    --color
    --require spec_helper
