### PR TITLE
Fix silently failing specs

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -8,7 +8,7 @@ class Place < ActiveRecord::Base
 
   geocoded_by :address
 
-  after_validation :set_coordinates, if: :geocoding_necessary?
+  before_save :set_coordinates, if: :geocoding_necessary?
 
   include AASM
   aasm column: 'state' do
@@ -32,7 +32,7 @@ class Place < ActiveRecord::Base
   private
 
   def address_changed?
-    (changed & [street, zip_code, city, country_code]).any?
+    (changed & ['street', 'zip_code', 'city', 'country_code']).any?
   end
 
   def geocoding_necessary?

--- a/spec/factories/places.rb
+++ b/spec/factories/places.rb
@@ -3,17 +3,25 @@ FactoryGirl.define do
     name 'Craftsmen Angers'
     kind Kind.codes.first
     state :pending
-    latitude 48.8724029
-    longitude 2.7768103
-    street '25 rue Lenepveu'
-    zip_code '49100'
-    city 'Angers'
     url 'http://craftsmen.io'
     logo_url 'https://pbs.twimg.com/profile_images/425256684244566016/N0wcdLyQ_400x400.jpeg'
     twitter_name 'craftsmenhq'
     description 'This could be a long description'
     owner_name 'Sébastien Charrier'
     owner_email 'sebastien@craftsmen.io'
+
+    trait :in_angers do
+      street '25 rue Lenepveu'
+      city 'Angers'
+      zip_code '49100'
+      country_code 'FR'
+    end
+
+    trait :in_angers_with_coordinates do
+      in_angers
+      latitude 48.8724029
+      longitude 2.7768103
+    end
 
     trait :active do
       state :active

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -2,26 +2,28 @@ require 'rails_helper'
 
 describe Place do
   it { should validate_presence_of(:name) }
-  it { should allow_value(Place::KINDS.first).for(:kind) }
+  it { should allow_value(Kind.codes.first).for(:kind) }
   it { should_not allow_value(['Bar']).for(:kind) }
 
-  describe '#valid?' do
+  describe '#save' do
     it 'geocodes location when location coordinates has not been provided' do
-      stub_geocoding_request('Undefined address', 47.47, -0.55)
+      stub_geocoding_request('25 rue Lenepveu, 49100, Angers, FR', 47.47, -0.55)
 
-      place = Place.new(street: 'Undefined address')
-      place.valid?
+      place = build(:place, :in_angers)
+      place.save
 
       expect(place.latitude).to eq(47.47)
       expect(place.longitude).to eq(-0.55)
     end
 
     it 'geocodes location when updating location address' do
-      stub_geocoding_request('20 rue Pablo Picasso', 45.42, 4.42)
+      stub_geocoding_request('20 rue Pablo Picasso, 42000, Saint-Etienne, FR', 45.42, 4.42)
 
-      place = create(:place)
+      place = create(:place, :in_angers_with_coordinates)
       place.street = '20 rue Pablo Picasso'
-      place.valid?
+      place.zip_code = '42000'
+      place.city = 'Saint-Etienne'
+      place.save
 
       expect(place.latitude).to eq(45.42)
       expect(place.longitude).to eq(4.42)
@@ -30,17 +32,18 @@ describe Place do
     it 'does not geocode when initialized with latitude and longitude coordinates' do
       Place.geocoding_service = double('geocoding service', coordinates: nil)
 
-      place = build(:place)
-      place.valid?
+      place = build(:place, :in_angers_with_coordinates)
+      place.save
 
       expect(Place.geocoding_service).not_to have_received(:coordinates)
     end
 
     it 'does not geocode when address does not change' do
-      place = create(:place)
+      place = create(:place, :in_angers_with_coordinates)
       Place.geocoding_service = double('geocoding service', coordinates: nil)
 
-      place.valid?
+      place.name = 'foo'
+      place.save
 
       expect(Place.geocoding_service).not_to have_received(:coordinates)
     end

--- a/spec/requests/api/v1/user_can_list_places_spec.rb
+++ b/spec/requests/api/v1/user_can_list_places_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe 'GET /api/v1/places' do
   it 'returns places list' do
-    places = create_list(:place, 5, :active)
-    create(:place)
+    create_list(:place, 5, :in_angers_with_coordinates, :active)
+    create(:place, :in_angers_with_coordinates)
 
     get '/api/v1/places', nil, headers
 

--- a/spec/requests/api/v1/user_can_suggest_a_place_spec.rb
+++ b/spec/requests/api/v1/user_can_suggest_a_place_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'POST /api/v1/places' do
   it 'creates a new place and returns it' do
-    place = build(:place)
+    place = build(:place, :in_angers_with_coordinates)
 
     post "/api/v1/places", {
       name: place.name,
@@ -36,6 +36,7 @@ describe 'POST /api/v1/places' do
   end
 
   it 'returns an error when invalid' do
+    stub_geocoding_request('FR', 47.47, -0.55)
     post '/api/v1/places', {
       name: 'I should give a kind'
     }.to_json, headers

--- a/spec/services/csv_import_service_spec.rb
+++ b/spec/services/csv_import_service_spec.rb
@@ -5,20 +5,20 @@ describe CsvImportService do
     it 'returns true if all the records are valid' do
       importer = CsvImportService.new('Place', Rails.root.join('spec/fixtures/csv/valid.csv'))
 
-      expect(importer.valid?).to be_true
+      expect(importer).to be_valid
     end
 
     it "returns false if file doesn't exists" do
       importer = CsvImportService.new('Place', '/missing.csv')
 
-      expect(importer.valid?).to be_false
+      expect(importer).not_to be_valid
       expect(importer.errors.full_messages.first).to eq("File /missing.csv doesn't exist")
     end
 
     it 'returns false if one record is not valid' do
       importer = CsvImportService.new('Place', Rails.root.join('spec/fixtures/csv/not_valid.csv'))
 
-      expect(importer.valid?).to be_false
+      expect(importer).not_to be_valid
       expect(importer.errors.full_messages.first).to eq("Data error : Name can't be blank (line 2)")
     end
   end

--- a/spec/support/geocoding_service.rb
+++ b/spec/support/geocoding_service.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+  config.around do |example|
+    cached_geocoding_service = Place.geocoding_service
+    example.run
+    Place.geocoding_service = cached_geocoding_service
+  end
+end

--- a/spec/support/helpers/geocoder_helper.rb
+++ b/spec/support/helpers/geocoder_helper.rb
@@ -8,7 +8,7 @@ module GeocoderHelper
 end
 
 RSpec.configure do |config|
-  config.around(:each) do
+  config.before do
     FakeGeocoder.clear
   end
 end


### PR DESCRIPTION
Two separate problems were hidden, despite a green suite:
- RSpec config problem
  `geocoder_helper.rb` was breaking RSpec due to a bad configuration.
  It made RSpec see feature specs examples as passing, while it ignores them completely.
  After fixing the configuration (`before` instead of `around` for clearing `FakeGeocoder`),
  few specs became red, due to real problems with the code, or only missing stubs for geocoding requests.
- Double "geocoding service" leak
  This double was created in one example but leaks into another example.
  rspec-mocks' double doesn't allow that, so we needed to introduce `spec/support/geocoder_service.rb`
  that sets back `Place.geocoder_service` to it's original value after using a double in an example.
