### PR TITLE
Enable progress bar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'sass-rails'
 gem 'simple_form'
 gem 'thor'
 gem 'thor-rails'
-gem 'turbolinks'
+gem 'turbolinks', '~> 5.0.0.beta'
 gem 'uglifier'
 gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,8 +259,9 @@ GEM
     thread_safe (0.3.5)
     tilt (2.0.2)
     timecop (0.8.0)
-    turbolinks (2.5.3)
-      coffee-rails
+    turbolinks (5.0.0.beta2)
+      turbolinks-source
+    turbolinks-source (5.0.0.beta3)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.0)
@@ -323,7 +324,7 @@ DEPENDENCIES
   thor
   thor-rails
   timecop
-  turbolinks
+  turbolinks (~> 5.0.0.beta)
   uglifier
   unicorn
   webmock

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,8 +1,15 @@
 //= require jquery
+//= require jquery_ujs
 //= require turbolinks
 //= require_tree ./components
 //= require_self
 
-$(document).on('ready page:load', function() {
+$(document).on('turbolinks:load', function() {
+  // Use turbolinks to submit search form
+  $('.search-form').on('submit', function(event) {
+    Turbolinks.visit(this.action + '?' + $(this).serialize());
+    event.preventDefault();
+  });
+
   $('.place-map').mapWithMarker();
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,3 +13,9 @@ $(document).on('turbolinks:load', function() {
 
   $('.place-map').mapWithMarker();
 });
+
+// Workaround to have the good cache value in turbolink when restoring the page
+$(document).on('turbolinks:before-cache', function() {
+  var field = $('.search-field');
+  field.val(field.attr('value'));
+});

--- a/app/assets/javascripts/components/map_with_marker.js.erb
+++ b/app/assets/javascripts/components/map_with_marker.js.erb
@@ -1,19 +1,21 @@
 (function($) {
   $.fn.mapWithMarker = function() {
-    var center = new google.maps.LatLng(this.data('latitude'), this.data('longitude'));
-    var options = {
-      scrollwheel: false,
-      disableDefaultUI: true,
-      zoom: 14,
-      center: center,
-    };
+    if (this.length > 0) {
+      var center = new google.maps.LatLng(this.data('latitude'), this.data('longitude'));
+      var options = {
+        scrollwheel: false,
+        disableDefaultUI: true,
+        zoom: 14,
+        center: center,
+      };
 
-    var map = new google.maps.Map(this[0], options);
-    var marker = new google.maps.Marker({
-      map: map,
-      position: center,
-      icon: '<%= image_path('marker.png') %>'
-    });
+      var map = new google.maps.Map(this[0], options);
+      var marker = new google.maps.Marker({
+        map: map,
+        position: center,
+        icon: '<%= image_path('marker.png') %>'
+      });
+    }
 
     return this;
   }

--- a/app/assets/stylesheets/layout/_main.scss
+++ b/app/assets/stylesheets/layout/_main.scss
@@ -18,6 +18,6 @@ main {
 }
 
 .turbolinks-progress-bar {
-  height: 2px;
   background-color: $red;
+  height: 2px;
 }

--- a/app/assets/stylesheets/layout/_main.scss
+++ b/app/assets/stylesheets/layout/_main.scss
@@ -16,3 +16,8 @@ main {
 .container {
   @include outer-container;
 }
+
+.turbolinks-progress-bar {
+  height: 2px;
+  background-color: $red;
+}

--- a/app/views/places/_search.html.erb
+++ b/app/views/places/_search.html.erb
@@ -8,7 +8,8 @@
                              params[:q],
                              name: :q,
                              placeholder: 'Tapez pour chercher. Par exemple : design',
-                             autofocus: params[:q].blank? %>
+                             autofocus: params[:q].blank?,
+                             class: 'search-field' %>
 
         <%= button_tag title: 'Lancer la recherche', id: 'search-button', type: :submit do %>
           <%= fa_icon(:search) %>

--- a/app/views/places/_search.html.erb
+++ b/app/views/places/_search.html.erb
@@ -1,8 +1,9 @@
 <header class="places-search">
   <div>
     <h1>Trouver un partenaire tech à Angers.</h1>
-    <%= form_tag url_for(controller: :places, action: :index, page: 1), method: :get do %>
+    <%= form_tag url_for(controller: :places, action: :index), method: :get, class: 'search-form' do %>
       <div class="places-search-bar">
+        <%= hidden_field_tag :page, 1 %>
         <%= search_field_tag :search,
                              params[:q],
                              name: :q,


### PR DESCRIPTION
Upgrade turbolinks to v5 and use the new cache system to speed up pages rendering.
Display the turbolink progess bar for page responding in more than 500ms.